### PR TITLE
Fix misleading help text

### DIFF
--- a/frontend/src/components/NodeForm.tsx
+++ b/frontend/src/components/NodeForm.tsx
@@ -58,7 +58,7 @@ const helpText = {
         </p>
         <p>
           Make sure you do not upload your <code>readonly.macaroon</code> or
-          {' '}<code>invoice.macaroon</code> files accidentally.
+          {' '}<code>admin.macaroon</code> files accidentally.
         </p>
         <p>
           The macaroons are usually located:


### PR DESCRIPTION
This PR fixes the help text for the upload of `invoice.macaroon`.
It simply changes the warning message from 

> Make sure you do not upload your `invoice.macaroon`

to

> Make sure you do not upload your `admin.macaroon`

This is a fix for #29.